### PR TITLE
export: try to keep originals form id 

### DIFF
--- a/forms_model.php
+++ b/forms_model.php
@@ -1740,12 +1740,18 @@ class GFFormsModel {
 		}
 	}
 
-	public static function insert_form( $form_title ) {
+	public static function insert_form( $form_title, $desired_id = FALSE ) {
 		global $wpdb;
 		$form_table_name = self::get_form_table_name();
 
 		//creating new form
-		$wpdb->query( $wpdb->prepare( "INSERT INTO $form_table_name(title, date_created) VALUES(%s, utc_timestamp())", $form_title ) );
+		//test whether a specific id is desired *and* available
+		if ( $desired_id && !self::get_form( $desired_id, true ) ) {
+			$wpdb->query( $wpdb->prepare( "INSERT INTO $form_table_name(id, title, date_created) VALUES(%d, %s, utc_timestamp())", $desired_id, $form_title ) );
+		}
+		else {
+			$wpdb->query( $wpdb->prepare( "INSERT INTO $form_table_name(title, date_created) VALUES(%s, utc_timestamp())", $form_title ) );
+		}
 
 		//returning newly created form id
 		return $wpdb->insert_id;

--- a/includes/api.php
+++ b/includes/api.php
@@ -360,8 +360,8 @@ class GFAPI {
 			return new WP_Error( 'invalid', __( 'Invalid form objects', 'gravityforms' ) );
 		}
 		$form_ids = array();
-		foreach ( $forms as $form ) {
-			$result = self::add_form( $form );
+		foreach ( $forms as $key => $form ) {
+			$result = self::add_form( $form, $key );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
@@ -384,10 +384,11 @@ class GFAPI {
 	 * @uses GFFormsModel::update_form_meta()
 	 *
 	 * @param array $form_meta The Form object.
+	 * @param array $desired_id Form ID to use (if available)
 	 *
 	 * @return int|WP_Error Either the new Form ID or a WP_Error instance.
 	 */
-	public static function add_form( $form_meta ) {
+	public static function add_form( $form_meta, $desired_id = FALSE ) {
 		global $wpdb;
 
 		if ( gf_upgrade()->get_submissions_block() ) {
@@ -410,7 +411,7 @@ class GFAPI {
 		}
 
 		// Inserting form.
-		$form_id = RGFormsModel::insert_form( $title );
+		$form_id = RGFormsModel::insert_form( $title, $desired_id );
 
 		// Updating form meta.
 		$form_meta['title'] = $title;


### PR DESCRIPTION
Attempt to keep original form id when exporting in order to avoid ID mismatch when copying forms between two WP instances
tagging @acancado @JeffMatson @richardW8k @stevehenty @travislopes
